### PR TITLE
Update gradle build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Open Whisper Systems 
+Copyright (c) 2014 Open Whisper Systems
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ In the remote directory, the artifact consists of a POM file and a jar or aar, a
 sha1sum hash values for those files.
 
 When gradle retrieves the artifact, it will also retrieve the md5sum and sha1sums to verify that
-they match the calculated md5sum and sha1sum of the retrieved files.  The problem, obviously, is 
-that if someone is able to compromise the remote maven repository and change the jar/aar for a 
+they match the calculated md5sum and sha1sum of the retrieved files.  The problem, obviously, is
+that if someone is able to compromise the remote maven repository and change the jar/aar for a
 dependency to include some malicious functionality, they could just as easily change the md5sum
 and sha1sum values the repository advertises as well.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'groovy'
+apply plugin: 'java'
 
 dependencies {
     compile gradleApi()
@@ -11,4 +12,9 @@ targetCompatibility = '1.7'
 tasks.withType(AbstractArchiveTask) {
     preserveFileTimestamps = false
     reproducibleFileOrder = true
+}
+
+jar.doLast { task ->
+    ant.checksum file: task.archivePath
+    println "md5=" + file("build/libs/gradle-witness.jar.MD5").text.trim()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'groovy'
-apply plugin: 'java'
 
 dependencies {
     compile gradleApi()

--- a/build.gradle
+++ b/build.gradle
@@ -8,3 +8,7 @@ dependencies {
 sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,6 @@ dependencies {
     compile localGroovy()
 }
 
-sourceCompatibility = '1.10'
-targetCompatibility = '1.10'
-
 tasks.withType(AbstractArchiveTask) {
     preserveFileTimestamps = false
     reproducibleFileOrder = true

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     compile localGroovy()
 }
 
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+sourceCompatibility = '1.10'
+targetCompatibility = '1.10'
 
 tasks.withType(AbstractArchiveTask) {
     preserveFileTimestamps = false

--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -63,4 +63,3 @@ class WitnessPlugin implements Plugin<Project> {
         }
     }
 }
-


### PR DESCRIPTION
Resolves concerns discussed in https://github.com/bisq-network/bisq/pull/1901#issuecomment-437493277

- Update build.gradle to ensure reproducible builds
- Generate MD5 hash file and print it during gradle build
- Update source/target compatibility to 1.10