### PR TITLE
Sort output

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -52,7 +52,7 @@ class WitnessPlugin implements Plugin<Project> {
                 println "dependencyVerification {"
                 println "    verify = ["
 
-                project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
+                project.configurations.compile.resolvedConfiguration.resolvedArtifacts.toSorted{it.moduleVersion.toString()}.each {
                     dep ->
                         println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
                 }


### PR DESCRIPTION
Whenever dependencies are updated, it is quite an effort to just commit the changed checksums.

This PR sorts the artifacts alphabetically each time and thus, reduces the efforts required.

Motivated by https://github.com/bisq-network/bisq/pull/3585

Here is the checksum:
```
% ./gradlew clean build
[snip]
> Task :jar
md5=a42d3713bf35b1f52cfe9a3a605e4c52
```
